### PR TITLE
Add app.json for Expo Go compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,3 @@
-# Compiled class file
-*.class
-
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+node_modules
+.expo
+.DS_Store

--- a/App.js
+++ b/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import GenesisWorldScreen from './GenesisWorld/GenesisWorldScreen';
+
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <GenesisWorldScreen />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+});

--- a/GenesisWorld/GenesisWorldScreen.js
+++ b/GenesisWorld/GenesisWorldScreen.js
@@ -1,0 +1,109 @@
+import React, { useState, useRef } from 'react';
+import { View, Text, StyleSheet, Dimensions, TouchableOpacity } from 'react-native';
+import { GameEngine } from 'react-native-game-engine';
+import Player from './components/Player';
+import Block from './components/Block';
+import GenesisToken from './components/GenesisToken';
+import Controls from './components/Controls';
+import PhysicsSystem from './systems/physics';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+export default function GenesisWorldScreen() {
+  const engine = useRef(null);
+  const [tokenDropped, setTokenDropped] = useState(false);
+
+  const entities = {
+    player: {
+      position: [50, SCREEN_HEIGHT - 150],
+      size: [40, 40],
+      vx: 0,
+      vy: 0,
+      grounded: false,
+      renderer: <Player />,
+    },
+    floor: {
+      position: [0, SCREEN_HEIGHT - 100],
+      size: [SCREEN_WIDTH, 100],
+      renderer: <Block />,
+    },
+    token: {
+      position: [SCREEN_WIDTH - 80, SCREEN_HEIGHT - 140],
+      size: [60, 60],
+      activated: tokenDropped,
+      renderer: <GenesisToken />,
+    },
+  };
+
+  const [gameEntities, setGameEntities] = useState(entities);
+
+  const systems = [PhysicsSystem];
+
+  const handleLeft = () => {
+    setGameEntities((ents) => {
+      ents.player.vx = -3;
+      return { ...ents };
+    });
+  };
+
+  const handleRight = () => {
+    setGameEntities((ents) => {
+      ents.player.vx = 3;
+      return { ...ents };
+    });
+  };
+
+  const handleJump = () => {
+    setGameEntities((ents) => {
+      if (ents.player.grounded) {
+        ents.player.vy = -12;
+      }
+      return { ...ents };
+    });
+  };
+
+  const handleDropToken = () => {
+    setTokenDropped(true);
+    setGameEntities((ents) => {
+      ents.token.activated = true;
+      return { ...ents };
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <GameEngine
+        ref={engine}
+        style={styles.game}
+        systems={systems}
+        entities={gameEntities}
+      />
+      <Controls onLeft={handleLeft} onRight={handleRight} onJump={handleJump} />
+      {Math.abs(gameEntities.player.position[0] - gameEntities.token.position[0]) < 50 && (
+        <TouchableOpacity style={styles.dropButton} onPress={handleDropToken} disabled={tokenDropped}>
+          <Text style={{ color: '#0f0' }}>{tokenDropped ? 'Token Placed' : 'Drop Token'}</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  game: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  dropButton: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    backgroundColor: '#003300',
+    padding: 10,
+    borderColor: '#00ff00',
+    borderWidth: 1,
+  },
+});

--- a/GenesisWorld/components/Block.js
+++ b/GenesisWorld/components/Block.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export default function Block({ position, size, color = '#003300' }) {
+  const width = size[0];
+  const height = size[1];
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        left: position[0],
+        top: position[1],
+        width,
+        height,
+        backgroundColor: color,
+        borderColor: '#00ff00',
+        borderWidth: 1,
+      }}
+    />
+  );
+}

--- a/GenesisWorld/components/Controls.js
+++ b/GenesisWorld/components/Controls.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+export default function Controls({ onLeft, onRight, onJump }) {
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      <TouchableOpacity style={styles.button} onPressIn={onLeft}>
+        <Text style={styles.text}>Left</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPressIn={onRight}>
+        <Text style={styles.text}>Right</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPressIn={onJump}>
+        <Text style={styles.text}>Jump</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 20,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  button: {
+    backgroundColor: '#003300',
+    padding: 10,
+    borderColor: '#00ff00',
+    borderWidth: 1,
+  },
+  text: {
+    color: '#0f0',
+  },
+});

--- a/GenesisWorld/components/GenesisToken.js
+++ b/GenesisWorld/components/GenesisToken.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function GenesisToken({ position, size, activated }) {
+  const width = size[0];
+  const height = size[1];
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        left: position[0],
+        top: position[1],
+        width,
+        height,
+        backgroundColor: activated ? '#00ff00' : '#002200',
+        borderColor: '#00ff00',
+        borderWidth: 2,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Text style={{ color: '#0f0', fontSize: 12 }}>{activated ? 'Token Set' : 'Token Pillar'}</Text>
+    </View>
+  );
+}

--- a/GenesisWorld/components/Player.js
+++ b/GenesisWorld/components/Player.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Svg, Polygon } from 'react-native-svg';
+import { View } from 'react-native';
+
+export default function Player({ position, size, color = '#00ff00' }) {
+  const width = size[0];
+  const height = size[1];
+  const points = `0,${height} ${width / 2},0 ${width},${height}`;
+
+  return (
+    <View style={{ position: 'absolute', left: position[0], top: position[1], width, height }}>
+      <Svg width={width} height={height}>
+        <Polygon points={points} fill={color} />
+      </Svg>
+    </View>
+  );
+}

--- a/GenesisWorld/systems/controls.js
+++ b/GenesisWorld/systems/controls.js
@@ -1,0 +1,4 @@
+export default function ControlsSystem(entities, { touches }) {
+  const move = touches.find(x => x.type === 'move');
+  return entities;
+}

--- a/GenesisWorld/systems/physics.js
+++ b/GenesisWorld/systems/physics.js
@@ -1,0 +1,32 @@
+import { Dimensions } from 'react-native';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+export default function PhysicsSystem(entities) {
+  const player = entities.player;
+  const gravity = 0.6;
+
+  if (!player) return entities;
+
+  player.vy += gravity;
+  player.position[1] += player.vy;
+  player.position[0] += player.vx;
+
+  // Floor collision
+  const floorY = entities.floor.position[1];
+  if (player.position[1] + player.size[1] > floorY) {
+    player.position[1] = floorY - player.size[1];
+    player.vy = 0;
+    player.grounded = true;
+  } else {
+    player.grounded = false;
+  }
+
+  // Boundaries left/right
+  if (player.position[0] < 0) player.position[0] = 0;
+  if (player.position[0] + player.size[0] > SCREEN_WIDTH) {
+    player.position[0] = SCREEN_WIDTH - player.size[0];
+  }
+
+  return entities;
+}

--- a/app.json
+++ b/app.json
@@ -1,0 +1,14 @@
+{
+  "expo": {
+    "name": "GenesisWorld",
+    "slug": "genesisworld",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "updates": {
+      "url": "https://u.expo.dev/placeholder-project-id",
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "genesisworld",
+  "version": "1.0.0",
+  "main": "App.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~48.0.0",
+    "expo-status-bar": "~1.4.4",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "react-native-game-engine": "1.2.0",
+    "react-native-svg": "13.9.0"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Expo project with an `app.json`
- include `updates.url` so Expo Go doesn't use legacy manifest

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688929af96e08323aad75a2a0ae6e7cb