### PR TITLE
Update dependencies for Expo SDK 48

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "expo": "~48.0.0",
     "expo-status-bar": "~1.4.4",
     "react": "18.2.0",
-    "react-native": "0.71.8",
+    "react-native": "0.71.14",
     "react-native-game-engine": "1.2.0",
-    "react-native-svg": "13.9.0"
+    "react-native-svg": "13.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump `react-native` and `react-native-svg` to versions that match Expo SDK 48

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688946aae45c8323a41684ac0b720eff