### PR TITLE
Expand GenesisWorld gameplay

### DIFF
--- a/GenesisWorld/GenesisWorldScreen.js
+++ b/GenesisWorld/GenesisWorldScreen.js
@@ -1,43 +1,154 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions, TouchableOpacity } from 'react-native';
 import { GameEngine } from 'react-native-game-engine';
 import Player from './components/Player';
 import Block from './components/Block';
 import GenesisToken from './components/GenesisToken';
+import Enemy from './components/Enemy';
+import Bullet from './components/Bullet';
+import TextBox from './components/TextBox';
 import Controls from './components/Controls';
 import PhysicsSystem from './systems/physics';
+import EnemySystem from './systems/enemy';
+import BulletSystem from './systems/bullet';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 export default function GenesisWorldScreen() {
   const engine = useRef(null);
-  const [tokenDropped, setTokenDropped] = useState(false);
+  const [level, setLevel] = useState(0);
 
-  const entities = {
-    player: {
-      position: [50, SCREEN_HEIGHT - 150],
-      size: [40, 40],
-      vx: 0,
-      vy: 0,
-      grounded: false,
-      renderer: <Player />,
+  const levels = [
+    {
+      text: 'Welcome hero! Recover the Genesis Token.',
+      width: SCREEN_WIDTH * 3,
+      tokenPos: [SCREEN_WIDTH * 3 - 80, SCREEN_HEIGHT - 140],
+      enemies: [
+        { minX: 300, maxX: SCREEN_WIDTH * 3 - 200, y: SCREEN_HEIGHT - 140 },
+      ],
+      platforms: [
+        { x: 150, y: SCREEN_HEIGHT - 200, w: 120, h: 20 },
+      ],
     },
-    floor: {
-      position: [0, SCREEN_HEIGHT - 100],
-      size: [SCREEN_WIDTH, 100],
-      renderer: <Block />,
+    {
+      text: 'Beware of the roaming foes.',
+      width: SCREEN_WIDTH * 4,
+      tokenPos: [SCREEN_WIDTH * 4 - 80, SCREEN_HEIGHT - 220],
+      enemies: [
+        { minX: 200, maxX: SCREEN_WIDTH * 2, y: SCREEN_HEIGHT - 140 },
+        { minX: 600, maxX: SCREEN_WIDTH * 3, y: SCREEN_HEIGHT - 220 },
+      ],
+      platforms: [
+        { x: 300, y: SCREEN_HEIGHT - 160, w: 120, h: 20 },
+        { x: 700, y: SCREEN_HEIGHT - 240, w: 120, h: 20 },
+      ],
     },
-    token: {
-      position: [SCREEN_WIDTH - 80, SCREEN_HEIGHT - 140],
-      size: [60, 60],
-      activated: tokenDropped,
-      renderer: <GenesisToken />,
+    {
+      text: 'Final stretch, defeat all foes!',
+      width: SCREEN_WIDTH * 5,
+      tokenPos: [SCREEN_WIDTH * 5 - 80, SCREEN_HEIGHT - 300],
+      enemies: [
+        { minX: 400, maxX: SCREEN_WIDTH * 3, y: SCREEN_HEIGHT - 140 },
+        { minX: 800, maxX: SCREEN_WIDTH * 4, y: SCREEN_HEIGHT - 220 },
+        { minX: SCREEN_WIDTH * 3, maxX: SCREEN_WIDTH * 5 - 100, y: SCREEN_HEIGHT - 300 },
+      ],
+      platforms: [
+        { x: 500, y: SCREEN_HEIGHT - 180, w: 120, h: 20 },
+        { x: 1100, y: SCREEN_HEIGHT - 260, w: 120, h: 20 },
+        { x: 1400, y: SCREEN_HEIGHT - 340, w: 120, h: 20 },
+      ],
     },
+  ];
+
+  const [message, setMessage] = useState(levels[0].text);
+  const [tokenDropped, setTokenDropped] = useState(false);
+  const showMessage = (msg) => {
+    setMessage(msg);
+    setTimeout(() => setMessage(null), 3000);
   };
 
-  const [gameEntities, setGameEntities] = useState(entities);
+  const createEntities = (lvl) => {
+    const config = levels[lvl];
+    const base = {
+      player: {
+        position: [50, SCREEN_HEIGHT - 150],
+        size: [40, 40],
+        vx: 0,
+        vy: 0,
+        grounded: false,
+        cameraX: 0,
+        renderer: <Player />,
+      },
+      floor: {
+        position: [0, SCREEN_HEIGHT - 100],
+        size: [config.width, 100],
+        cameraX: 0,
+        renderer: <Block />,
+      },
+      token: {
+        position: config.tokenPos,
+        size: [60, 60],
+        activated: false,
+        cameraX: 0,
+        renderer: <GenesisToken />,
+      },
+      levelWidth: config.width,
+      camera: { offsetX: 0 },
+    };
 
-  const systems = [PhysicsSystem];
+    config.enemies.forEach((e, i) => {
+      base[`enemy${i}`] = {
+        position: [e.minX, e.y],
+        size: [40, 40],
+        vx: 2,
+        minX: e.minX,
+        maxX: e.maxX,
+        cameraX: 0,
+        renderer: <Enemy />,
+      };
+    });
+
+    if (config.platforms) {
+      config.platforms.forEach((p, i) => {
+        base[`platform${i}`] = {
+          position: [p.x, p.y],
+          size: [p.w, p.h],
+          cameraX: 0,
+          renderer: <Block />,
+        };
+      });
+    }
+
+    base.onPlayerHit = () => {};
+    return base;
+  };
+
+  const [gameEntities, setGameEntities] = useState(() => {
+    const ents = createEntities(0);
+    ents.showMessage = showMessage;
+    return ents;
+  });
+  const bulletRef = useRef(0);
+
+  const handlePlayerHit = () => {
+    showMessage('You were hit! Try again.');
+    setTokenDropped(false);
+    const newEntities = createEntities(level);
+    newEntities.onPlayerHit = handlePlayerHit;
+    newEntities.showMessage = showMessage;
+    setGameEntities(newEntities);
+  };
+
+  useEffect(() => {
+    setGameEntities((ents) => ({ ...ents, onPlayerHit: handlePlayerHit, showMessage }));
+    showMessage(levels[0].text);
+  }, []);
+
+  useEffect(() => {
+    showMessage(levels[level].text);
+  }, [level]);
+
+  const systems = [PhysicsSystem, EnemySystem, BulletSystem];
 
   const handleLeft = () => {
     setGameEntities((ents) => {
@@ -46,9 +157,23 @@ export default function GenesisWorldScreen() {
     });
   };
 
+  const handleLeftRelease = () => {
+    setGameEntities((ents) => {
+      ents.player.vx = 0;
+      return { ...ents };
+    });
+  };
+
   const handleRight = () => {
     setGameEntities((ents) => {
       ents.player.vx = 3;
+      return { ...ents };
+    });
+  };
+
+  const handleRightRelease = () => {
+    setGameEntities((ents) => {
+      ents.player.vx = 0;
       return { ...ents };
     });
   };
@@ -62,12 +187,42 @@ export default function GenesisWorldScreen() {
     });
   };
 
+  const handleShoot = () => {
+    setGameEntities((ents) => {
+      bulletRef.current += 1;
+      const key = `bullet${bulletRef.current}`;
+      ents[key] = {
+        position: [ents.player.position[0] + ents.player.size[0], ents.player.position[1] + ents.player.size[1] / 2],
+        size: [10, 4],
+        vx: 6,
+        cameraX: 0,
+        renderer: <Bullet />,
+      };
+      return { ...ents };
+    });
+  };
+
   const handleDropToken = () => {
     setTokenDropped(true);
     setGameEntities((ents) => {
       ents.token.activated = true;
       return { ...ents };
     });
+    showMessage('Great! Token secured.');
+    setTimeout(() => {
+      if (level < levels.length - 1) {
+        const next = level + 1;
+        setLevel(next);
+        showMessage(levels[next].text);
+        setTokenDropped(false);
+        const nextEntities = createEntities(next);
+        nextEntities.onPlayerHit = handlePlayerHit;
+        nextEntities.showMessage = showMessage;
+        setGameEntities(nextEntities);
+      } else {
+        showMessage('You recovered all tokens! The realm is saved.');
+      }
+    }, 500);
   };
 
   return (
@@ -78,7 +233,15 @@ export default function GenesisWorldScreen() {
         systems={systems}
         entities={gameEntities}
       />
-      <Controls onLeft={handleLeft} onRight={handleRight} onJump={handleJump} />
+      <Controls
+        onLeft={handleLeft}
+        onLeftRelease={handleLeftRelease}
+        onRight={handleRight}
+        onRightRelease={handleRightRelease}
+        onJump={handleJump}
+        onShoot={handleShoot}
+      />
+      <TextBox text={message} />
       {Math.abs(gameEntities.player.position[0] - gameEntities.token.position[0]) < 50 && (
         <TouchableOpacity style={styles.dropButton} onPress={handleDropToken} disabled={tokenDropped}>
           <Text style={{ color: '#0f0' }}>{tokenDropped ? 'Token Placed' : 'Drop Token'}</Text>

--- a/GenesisWorld/components/Bullet.js
+++ b/GenesisWorld/components/Bullet.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 
-export default function Block({ position, size, color = '#003300', cameraX = 0 }) {
+export default function Bullet({ position, size, cameraX = 0 }) {
   const width = size[0];
   const height = size[1];
   return (
@@ -12,9 +12,7 @@ export default function Block({ position, size, color = '#003300', cameraX = 0 }
         top: position[1],
         width,
         height,
-        backgroundColor: color,
-        borderColor: '#00ff00',
-        borderWidth: 1,
+        backgroundColor: '#ffff00',
       }}
     />
   );

--- a/GenesisWorld/components/Controls.js
+++ b/GenesisWorld/components/Controls.js
@@ -1,17 +1,35 @@
 import React from 'react';
 import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
 
-export default function Controls({ onLeft, onRight, onJump }) {
+export default function Controls({
+  onLeft,
+  onLeftRelease,
+  onRight,
+  onRightRelease,
+  onJump,
+  onShoot,
+}) {
   return (
     <View style={styles.container} pointerEvents="box-none">
-      <TouchableOpacity style={styles.button} onPressIn={onLeft}>
+      <TouchableOpacity
+        style={styles.button}
+        onPressIn={onLeft}
+        onPressOut={onLeftRelease}
+      >
         <Text style={styles.text}>Left</Text>
       </TouchableOpacity>
-      <TouchableOpacity style={styles.button} onPressIn={onRight}>
+      <TouchableOpacity
+        style={styles.button}
+        onPressIn={onRight}
+        onPressOut={onRightRelease}
+      >
         <Text style={styles.text}>Right</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPressIn={onJump}>
         <Text style={styles.text}>Jump</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPressIn={onShoot}>
+        <Text style={styles.text}>Shoot</Text>
       </TouchableOpacity>
     </View>
   );

--- a/GenesisWorld/components/Enemy.js
+++ b/GenesisWorld/components/Enemy.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 
-export default function Block({ position, size, color = '#003300', cameraX = 0 }) {
+export default function Enemy({ position, size, cameraX = 0 }) {
   const width = size[0];
   const height = size[1];
   return (
@@ -12,9 +12,9 @@ export default function Block({ position, size, color = '#003300', cameraX = 0 }
         top: position[1],
         width,
         height,
-        backgroundColor: color,
-        borderColor: '#00ff00',
-        borderWidth: 1,
+        backgroundColor: '#440000',
+        borderColor: '#ff0000',
+        borderWidth: 2,
       }}
     />
   );

--- a/GenesisWorld/components/GenesisToken.js
+++ b/GenesisWorld/components/GenesisToken.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 
-export default function GenesisToken({ position, size, activated }) {
+export default function GenesisToken({ position, size, activated, cameraX = 0 }) {
   const width = size[0];
   const height = size[1];
   return (
     <View
       style={{
         position: 'absolute',
-        left: position[0],
+        left: position[0] - cameraX,
         top: position[1],
         width,
         height,

--- a/GenesisWorld/components/Player.js
+++ b/GenesisWorld/components/Player.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import { Svg, Polygon } from 'react-native-svg';
+import { Svg, Circle, Rect } from 'react-native-svg';
 import { View } from 'react-native';
 
-export default function Player({ position, size, color = '#00ff00' }) {
+export default function Player({ position, size, color = '#00ff00', cameraX = 0 }) {
   const width = size[0];
   const height = size[1];
-  const points = `0,${height} ${width / 2},0 ${width},${height}`;
-
+  const bodyHeight = height * 0.6;
+  const headRadius = height * 0.2;
   return (
-    <View style={{ position: 'absolute', left: position[0], top: position[1], width, height }}>
+    <View style={{ position: 'absolute', left: position[0] - cameraX, top: position[1], width, height }}>
       <Svg width={width} height={height}>
-        <Polygon points={points} fill={color} />
+        <Circle cx={width / 2} cy={headRadius} r={headRadius} fill={color} />
+        <Rect x={width * 0.25} y={headRadius * 2} width={width * 0.5} height={bodyHeight} fill={color} />
       </Svg>
     </View>
   );

--- a/GenesisWorld/components/TextBox.js
+++ b/GenesisWorld/components/TextBox.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function TextBox({ text }) {
+  if (!text) return null;
+  return (
+    <View style={styles.container} pointerEvents="none">
+      <Text style={styles.text}>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 20,
+    left: 20,
+    right: 20,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    borderColor: '#00ff00',
+    borderWidth: 1,
+    padding: 10,
+  },
+  text: {
+    color: '#0f0',
+    textAlign: 'center',
+  },
+});

--- a/GenesisWorld/systems/bullet.js
+++ b/GenesisWorld/systems/bullet.js
@@ -1,0 +1,32 @@
+export default function BulletSystem(entities) {
+  const showMessage = entities.showMessage;
+  Object.keys(entities).forEach((key) => {
+    if (key.startsWith('bullet')) {
+      const bullet = entities[key];
+      bullet.position[0] += bullet.vx;
+      if (bullet.position[0] > entities.levelWidth) {
+        delete entities[key];
+      } else {
+        Object.keys(entities).forEach((eKey) => {
+          if (eKey.startsWith('enemy')) {
+            const enemy = entities[eKey];
+            const bx = bullet.position[0];
+            const by = bullet.position[1];
+            const bw = bullet.size[0];
+            const bh = bullet.size[1];
+            const ex = enemy.position[0];
+            const ey = enemy.position[1];
+            const ew = enemy.size[0];
+            const eh = enemy.size[1];
+            if (bx < ex + ew && bx + bw > ex && by < ey + eh && by + bh > ey) {
+              delete entities[eKey];
+              delete entities[key];
+              if (typeof showMessage === 'function') showMessage('Enemy defeated!');
+            }
+          }
+        });
+      }
+    }
+  });
+  return entities;
+}

--- a/GenesisWorld/systems/enemy.js
+++ b/GenesisWorld/systems/enemy.js
@@ -1,0 +1,31 @@
+export default function EnemySystem(entities) {
+  const { player, onPlayerHit } = entities;
+  Object.keys(entities).forEach((key) => {
+    if (key.startsWith('enemy')) {
+      const enemy = entities[key];
+      enemy.position[0] += enemy.vx;
+      if (enemy.position[0] < enemy.minX || enemy.position[0] > enemy.maxX) {
+        enemy.vx *= -1;
+      }
+      if (player) {
+        const px = player.position[0];
+        const py = player.position[1];
+        const pw = player.size[0];
+        const ph = player.size[1];
+        const ex = enemy.position[0];
+        const ey = enemy.position[1];
+        const ew = enemy.size[0];
+        const eh = enemy.size[1];
+        if (
+          px < ex + ew &&
+          px + pw > ex &&
+          py < ey + eh &&
+          py + ph > ey
+        ) {
+          if (typeof onPlayerHit === 'function') onPlayerHit();
+        }
+      }
+    }
+  });
+  return entities;
+}

--- a/GenesisWorld/systems/physics.js
+++ b/GenesisWorld/systems/physics.js
@@ -18,14 +18,44 @@ export default function PhysicsSystem(entities) {
     player.position[1] = floorY - player.size[1];
     player.vy = 0;
     player.grounded = true;
-  } else {
-    player.grounded = false;
   }
 
-  // Boundaries left/right
+  // Platform collisions
+  Object.keys(entities).forEach((key) => {
+    if (key.startsWith('platform')) {
+      const platform = entities[key];
+      if (
+        player.vy >= 0 &&
+        player.position[1] + player.size[1] >= platform.position[1] &&
+        player.position[1] + player.size[1] - player.vy <= platform.position[1] &&
+        player.position[0] + player.size[0] > platform.position[0] &&
+        player.position[0] < platform.position[0] + platform.size[0]
+      ) {
+        player.position[1] = platform.position[1] - player.size[1];
+        player.vy = 0;
+        player.grounded = true;
+      }
+    }
+  });
+
+  // Boundaries left/right within level width
   if (player.position[0] < 0) player.position[0] = 0;
-  if (player.position[0] + player.size[0] > SCREEN_WIDTH) {
-    player.position[0] = SCREEN_WIDTH - player.size[0];
+  const levelWidth = entities.levelWidth || SCREEN_WIDTH;
+  if (player.position[0] + player.size[0] > levelWidth) {
+    player.position[0] = levelWidth - player.size[0];
+  }
+
+  // Update camera offset
+  if (entities.camera) {
+    entities.camera.offsetX = Math.min(
+      Math.max(0, player.position[0] - SCREEN_WIDTH / 2),
+      levelWidth - SCREEN_WIDTH
+    );
+    Object.keys(entities).forEach((key) => {
+      if (entities[key] && entities[key].position) {
+        entities[key].cameraX = entities.camera.offsetX;
+      }
+    });
   }
 
   return entities;


### PR DESCRIPTION
## Summary
- implement longer levels with platforms and scrolling camera
- add bullet shooting and enemy defeat messages
- refine on-screen controls with press/release actions
- hide text boxes after a short delay

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a9ed589b88323bd55846b6702885e